### PR TITLE
2 웹페이지내 전반적으로 존재하는 경고 제거와 스타일 통일

### DIFF
--- a/src/Routes/EventList/EventListTable.js
+++ b/src/Routes/EventList/EventListTable.js
@@ -304,7 +304,7 @@ const EventListTable = ({ data }) => {
               <PageChangeButton
                 text="edit"
                 href={"/eventdetail/" + event.eventId}
-                width="50"
+                width={50}
               />
             </td>
           </tr>


### PR DESCRIPTION
변경사항
PageChangeButton 에서 props인 width 를 string으로 넘겨 주었던것을 수정
결과
경고가 제거됨