### PR TITLE
2 웹페이지내 전반적으로 존재하는 경고 제거와 스타일 통일 - ProductDetail

### DIFF
--- a/src/Routes/ProductDetail/BasicInformation.js
+++ b/src/Routes/ProductDetail/BasicInformation.js
@@ -228,72 +228,74 @@ export default () => {
     <>
       <SectionTitle text="Basic Information" />
       <Table>
-        <tr>
-          <th>Product ID</th>
-          <td className="smallerCell">
-            {ProductInfoState.BasicInformation.productId}
-          </td>
-          <th rowSpan="3">Product Image</th>
-          <td rowSpan="3">
-            <ImageInputBox>
-              <Input
-                type="file"
-                accept="image/jpg,image/png,image/jpeg"
-                name="ProductImageInput"
-                onChange={(e) => ChangeImage(e)}
+        <tbody>
+          <tr>
+            <th>Product ID</th>
+            <td className="smallerCell">
+              {ProductInfoState.BasicInformation.productId}
+            </td>
+            <th rowSpan="3">Product Image</th>
+            <td rowSpan="3">
+              <ImageInputBox>
+                <Input
+                  type="file"
+                  accept="image/jpg,image/png,image/jpeg"
+                  name="ProductImageInput"
+                  onChange={(e) => ChangeImage(e)}
+                />
+                {productImage_Preview}
+              </ImageInputBox>
+              <Button
+                text={"Delete Photo"}
+                isButtonType={true}
+                ClickEvent={(e) => DeleteImage(e)}
               />
-              {productImage_Preview}
-            </ImageInputBox>
-            <Button
-              text={"Delete Photo"}
-              isButtonType={true}
-              ClickEvent={(e) => DeleteImage(e)}
-            />
-          </td>
-        </tr>
-        <tr>
-          <th>Product Name</th>
-          <td className="smallerCell">
-            <Input
-              InputWidth={300}
-              type="text"
-              name="ProductNameInput"
-              value={ProductInfoState.BasicInformation.productName.value}
-              onChange={(e) => onChange(e)}
-            />
-          </td>
-        </tr>
-        <tr>
-          <th>Price</th>
-          <td className="smallerCell">
-            <Input
-              InputWidth={300}
-              type="text"
-              name="PriceInput"
-              value={ProductInfoState.BasicInformation.price.value}
-              onChange={(e) => onChange(e)}
-            />
-          </td>
-        </tr>
-        <tr>
-          <th>Link URL</th>
-          <td colSpan="3" id="AddressCell">
-            <AddressCellWrapper>
+            </td>
+          </tr>
+          <tr>
+            <th>Product Name</th>
+            <td className="smallerCell">
               <Input
-                InputWidth={900}
+                InputWidth={300}
                 type="text"
-                name="ShopLinkInput"
-                value={ProductInfoState.BasicInformation.externalLink.value}
+                name="ProductNameInput"
+                value={ProductInfoState.BasicInformation.productName.value}
                 onChange={(e) => onChange(e)}
               />
-              <Button
-                text={"Check"}
-                isButtonType={true}
-                ClickEvent={CheckLink}
+            </td>
+          </tr>
+          <tr>
+            <th>Price</th>
+            <td className="smallerCell">
+              <Input
+                InputWidth={300}
+                type="text"
+                name="PriceInput"
+                value={ProductInfoState.BasicInformation.price.value}
+                onChange={(e) => onChange(e)}
               />
-            </AddressCellWrapper>
-          </td>
-        </tr>
+            </td>
+          </tr>
+          <tr>
+            <th>Link URL</th>
+            <td colSpan="3" id="AddressCell">
+              <AddressCellWrapper>
+                <Input
+                  InputWidth={900}
+                  type="text"
+                  name="ShopLinkInput"
+                  value={ProductInfoState.BasicInformation.externalLink.value}
+                  onChange={(e) => onChange(e)}
+                />
+                <Button
+                  text={"Check"}
+                  isButtonType={true}
+                  ClickEvent={CheckLink}
+                />
+              </AddressCellWrapper>
+            </td>
+          </tr>
+        </tbody>
       </Table>
     </>
   );

--- a/src/Routes/ProductDetail/BasicStatus.js
+++ b/src/Routes/ProductDetail/BasicStatus.js
@@ -75,18 +75,20 @@ export default () => {
     <>
       <SectionTitle text="Basic Status" />
       <Table>
-        <tr>
-          <th>Total Number of Posts</th>
-          <td colSpan="3" className="smallerCell">
-            # {ProductInfoState.BasicStatus.TotalNumberofPosts}
-          </td>
-        </tr>
-        <tr>
-          <th>Registration Date</th>
-          <td>{registrationDate}</td>
-          <th>Last Updated</th>
-          <td>{updatedDate}</td>
-        </tr>
+        <tbody>
+          <tr>
+            <th>Total Number of Posts</th>
+            <td colSpan="3" className="smallerCell">
+              # {ProductInfoState.BasicStatus.TotalNumberofPosts}
+            </td>
+          </tr>
+          <tr>
+            <th>Registration Date</th>
+            <td>{registrationDate}</td>
+            <th>Last Updated</th>
+            <td>{updatedDate}</td>
+          </tr>
+        </tbody>
       </Table>
     </>
   );

--- a/src/Routes/ProductDetail/BranchManagement/AutoSelectBox.js
+++ b/src/Routes/ProductDetail/BranchManagement/AutoSelectBox.js
@@ -18,13 +18,14 @@ const AutoSelectBox = ({ data, defaultValue, onChangeFunc, onSelectFunc }) => {
   return (
     <Autocomplete
       style={{ width: "100%" }}
-      options={data}
+      options={[...[defaultValue], ...data]}
       classes={{
         option: classes.option,
       }}
       autoHighlight
       getOptionLabel={(option) => option.shopName}
-      defaultValue={defaultValue}
+      value={defaultValue}
+      filterSelectedOptions
       renderOption={(option) => (
         <React.Fragment>
           <span>{option.id}</span>

--- a/src/Routes/ProductDetail/BranchManagement/BranchList.js
+++ b/src/Routes/ProductDetail/BranchManagement/BranchList.js
@@ -87,7 +87,7 @@ export default () => {
         </thead>
         <tbody>
           {branchData.getProductSellingShopBranch.branches.map((eachRow) => (
-            <BranchRowData data={eachRow} />
+            <BranchRowData data={eachRow} key={eachRow.id} />
           ))}
         </tbody>
       </Table>

--- a/src/Routes/ProductDetail/BranchManagement/BranchList.js
+++ b/src/Routes/ProductDetail/BranchManagement/BranchList.js
@@ -61,29 +61,35 @@ export default () => {
   if (branchError || branchLoading) {
     return (
       <Table>
-        <tr>
-          <th className="orderInputCell">Branch ID</th>
-          <th>Branch Name</th>
-          <th>Phone Number</th>
-          <th className="AddressCell">Address</th>
-          <th className="buttonCell">Select</th>
-        </tr>
+        <thead>
+          <tr>
+            <th className="orderInputCell">Branch ID</th>
+            <th>Branch Name</th>
+            <th>Phone Number</th>
+            <th className="AddressCell">Address</th>
+            <th className="buttonCell">Select</th>
+          </tr>
+        </thead>
       </Table>
     );
   }
   if (!branchLoading && branchData) {
     return (
       <Table>
-        <tr>
-          <th className="orderInputCell">Branch ID</th>
-          <th>Branch Name</th>
-          <th>Phone Number</th>
-          <th className="AddressCell">Address</th>
-          <th className="buttonCell"> Select</th>
-        </tr>
-        {branchData.getProductSellingShopBranch.branches.map((eachRow) => (
-          <BranchRowData data={eachRow} />
-        ))}
+        <thead>
+          <tr>
+            <th className="orderInputCell">Branch ID</th>
+            <th>Branch Name</th>
+            <th>Phone Number</th>
+            <th className="AddressCell">Address</th>
+            <th className="buttonCell"> Select</th>
+          </tr>
+        </thead>
+        <tbody>
+          {branchData.getProductSellingShopBranch.branches.map((eachRow) => (
+            <BranchRowData data={eachRow} />
+          ))}
+        </tbody>
       </Table>
     );
   }

--- a/src/Routes/ProductDetail/BranchManagement/BranchRowData.js
+++ b/src/Routes/ProductDetail/BranchManagement/BranchRowData.js
@@ -24,15 +24,14 @@ export default ({ data }) => {
     const { name } = e.target;
     if (name === "BranchSelectInput") {
       let isExist = false;
-      const rtnData = ProductInfoState.BranchManagement.value.filter(
-        (eachData) => {
-          if (eachData === Number(data.id)) {
-            isExist = true;
-          } else {
-            return eachData;
-          }
+      const rtnData = [];
+      for (const eachData of ProductInfoState.BranchManagement.value) {
+        if (eachData === Number(data.id)) {
+          isExist = true;
+        } else {
+          rtnData.push(eachData);
         }
-      );
+      }
       if (!isExist) rtnData.push(Number(data.id));
       ProductInfoDispatch({
         type: "UPDATE_BRANCH",

--- a/src/Routes/ProductDetail/BranchManagement/BranchRowData.js
+++ b/src/Routes/ProductDetail/BranchManagement/BranchRowData.js
@@ -21,7 +21,7 @@ export default ({ data }) => {
   );
 
   const onChange = (e) => {
-    const { value, name } = e.target;
+    const { name } = e.target;
     if (name === "BranchSelectInput") {
       let isExist = false;
       const rtnData = ProductInfoState.BranchManagement.value.filter(

--- a/src/Routes/ProductDetail/BranchManagement/ShopSelectInfo.js
+++ b/src/Routes/ProductDetail/BranchManagement/ShopSelectInfo.js
@@ -153,40 +153,48 @@ export default () => {
   return (
     <>
       <Table>
-        <tr>
-          <th className="shopIdCell">Shop ID</th>
-          <th>Shop Name</th>
-          <th className="shopLinkCell">Shop externalLink</th>
-        </tr>
-        <tr>
-          <td className="shopIdCell">
-            {ProductInfoState.SelectedShop.shopId > 0
-              ? ProductInfoState.SelectedShop.shopId
-              : "-"}
-          </td>
-          <td>
-            <AutoSelectBox
-              defaultValue={{
-                id: ProductInfoState.SelectedShop.shopId,
-                shopName: ProductInfoState.SelectedShop.shopName,
-                shopLink: ProductInfoState.SelectedShop.shopLink,
-                __typename: "ShopOption",
-              }}
-              data={ProductInfoState.ShopData}
-              onChangeFunc={onShopNameChange}
-              onSelectFunc={onShopNameSelect}
-            />
-          </td>
-          <td className="shopLinkCell">
-            <ShopLinkWrapper>
-              {!ProductInfoState.SelectedShop.shopLink ||
-              ProductInfoState.SelectedShop.shopLink === ""
-                ? "LINK DOES NOT EXIST"
-                : ProductInfoState.SelectedShop.shopLink}
-            </ShopLinkWrapper>
-            <Button text={"Check"} isButtonType={true} ClickEvent={CheckLink} />
-          </td>
-        </tr>
+        <thead>
+          <tr>
+            <th className="shopIdCell">Shop ID</th>
+            <th>Shop Name</th>
+            <th className="shopLinkCell">Shop externalLink</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="shopIdCell">
+              {ProductInfoState.SelectedShop.shopId > 0
+                ? ProductInfoState.SelectedShop.shopId
+                : "-"}
+            </td>
+            <td>
+              <AutoSelectBox
+                defaultValue={{
+                  id: ProductInfoState.SelectedShop.shopId,
+                  shopName: ProductInfoState.SelectedShop.shopName,
+                  shopLink: ProductInfoState.SelectedShop.shopLink,
+                  __typename: "ShopOption",
+                }}
+                data={ProductInfoState.ShopData}
+                onChangeFunc={onShopNameChange}
+                onSelectFunc={onShopNameSelect}
+              />
+            </td>
+            <td className="shopLinkCell">
+              <ShopLinkWrapper>
+                {!ProductInfoState.SelectedShop.shopLink ||
+                ProductInfoState.SelectedShop.shopLink === ""
+                  ? "LINK DOES NOT EXIST"
+                  : ProductInfoState.SelectedShop.shopLink}
+              </ShopLinkWrapper>
+              <Button
+                text={"Check"}
+                isButtonType={true}
+                ClickEvent={CheckLink}
+              />
+            </td>
+          </tr>
+        </tbody>
       </Table>
     </>
   );

--- a/src/Routes/ProductDetail/ProductDescription.js
+++ b/src/Routes/ProductDetail/ProductDescription.js
@@ -57,16 +57,18 @@ export default () => {
     <>
       <SectionTitle text="Product Description" />
       <Table>
-        <tr>
-          <th>Product Description</th>
-          <td>
-            <TextInput
-              name="ProductDescriptionInput"
-              value={ProductInfoState.ProductDescription.value}
-              onChange={(e) => onChange(e)}
-            />
-          </td>
-        </tr>
+        <tbody>
+          <tr>
+            <th>Product Description</th>
+            <td>
+              <TextInput
+                name="ProductDescriptionInput"
+                value={ProductInfoState.ProductDescription.value}
+                onChange={(e) => onChange(e)}
+              />
+            </td>
+          </tr>
+        </tbody>
       </Table>
     </>
   );

--- a/src/Routes/ProductDetail/ProductDetailPresenter.js
+++ b/src/Routes/ProductDetail/ProductDetailPresenter.js
@@ -53,10 +53,6 @@ export default ({
   tagMutationError,
   tagMutationLoading,
 }) => {
-  const { ProductInfoState, ProductInfoDispatch } = useContext(
-    ProductInfoContext
-  );
-
   if (error) {
     return <WrapPage>`Error! ${error.message}`</WrapPage>;
   }
@@ -69,6 +65,9 @@ export default ({
   }
 
   if (!loading && data) {
+    const { ProductInfoState, ProductInfoDispatch } = useContext(
+      ProductInfoContext
+    );
     useEffect(() => {
       try {
         let rtnBranches = [],

--- a/src/Routes/ProductDetail/TagInformation/TagDataRow.js
+++ b/src/Routes/ProductDetail/TagInformation/TagDataRow.js
@@ -124,17 +124,17 @@ export default ({ data }) => {
       <tr>
         <td className="orderInputCell">0</td>
         <td>
-          <select name="category">
+          <select name="category" onChange={() => 0}>
             <option value={"-- LOADING --"}>{"-- LOADING --"}</option>
           </select>
         </td>
         <td>
-          <select name="classInfo">
+          <select name="classInfo" onChange={() => 0}>
             <option value={0}>{"-- LOADING --"}</option>
           </select>
         </td>
         <td>
-          <select name="tagInfo" value={data.tagId}>
+          <select name="tagInfo" value={data.tagId} onChange={() => 0}>
             <option value={0}>{"-- LOADING --"}</option>
           </select>
         </td>

--- a/src/Routes/ProductDetail/TagInformation/TagDataRow.js
+++ b/src/Routes/ProductDetail/TagInformation/TagDataRow.js
@@ -162,8 +162,10 @@ export default ({ data }) => {
             ) : (
               <></>
             )}
-            {categories.map((category) => (
-              <option value={category}>{category}</option>
+            {categories.map((category, index) => (
+              <option value={category} key={index}>
+                {category}
+              </option>
             ))}
           </SelectBox>
         </td>
@@ -179,8 +181,10 @@ export default ({ data }) => {
               <></>
             )}
             {data.category !== "-- CHOOSE DATA --" ? (
-              classData.getClassOptions.map((item) => (
-                <option value={item.id}>{item.name}</option>
+              classData.getClassOptions.map((item, index) => (
+                <option value={item.id} key={index}>
+                  {item.name}
+                </option>
               ))
             ) : (
               <></>
@@ -195,8 +199,10 @@ export default ({ data }) => {
               <></>
             )}
             {data.classId !== 0 ? (
-              tagData.getTagOptions.map((item) => (
-                <option value={item.id}>{item.name}</option>
+              tagData.getTagOptions.map((item, index) => (
+                <option value={item.id} key={index}>
+                  {item.name}
+                </option>
               ))
             ) : (
               <></>

--- a/src/Routes/ProductDetail/TagInformation/TagInformationContainer.js
+++ b/src/Routes/ProductDetail/TagInformation/TagInformationContainer.js
@@ -136,20 +136,24 @@ export default ({ tagMutation, tagMutationError, tagMutationLoading }) => {
         <Button text="Get ShopTag" ClickEvent={handleTagUpdate} />
       </SectionContainer>
       <Table>
-        <tr>
-          <th className="orderInputCell">No</th>
-          <th>Tag Type</th>
-          <th>Class</th>
-          <th>Tag</th>
-          <th className="buttonCell">
-            <RowButton onClick={(e) => addRow(e)}>
-              <PlusIcon size={19} />
-            </RowButton>
-          </th>
-        </tr>
-        {ProductInfoState.TagInformation.value.map((eachRow) => (
-          <TagDataRow data={eachRow} />
-        ))}
+        <thead>
+          <tr>
+            <th className="orderInputCell">No</th>
+            <th>Tag Type</th>
+            <th>Class</th>
+            <th>Tag</th>
+            <th className="buttonCell">
+              <RowButton onClick={(e) => addRow(e)}>
+                <PlusIcon size={19} />
+              </RowButton>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {ProductInfoState.TagInformation.value.map((eachRow) => (
+            <TagDataRow data={eachRow} />
+          ))}
+        </tbody>
       </Table>
     </>
   );

--- a/src/Routes/ProductDetail/TagInformation/TagInformationContainer.js
+++ b/src/Routes/ProductDetail/TagInformation/TagInformationContainer.js
@@ -151,7 +151,7 @@ export default ({ tagMutation, tagMutationError, tagMutationLoading }) => {
         </thead>
         <tbody>
           {ProductInfoState.TagInformation.value.map((eachRow) => (
-            <TagDataRow data={eachRow} />
+            <TagDataRow data={eachRow} key={eachRow.id} />
           ))}
         </tbody>
       </Table>

--- a/src/Routes/ProductDetail/putImagetoS3.js
+++ b/src/Routes/ProductDetail/putImagetoS3.js
@@ -1,4 +1,4 @@
-import { IAM_ID, IAM_SECRETKEY, BUCKET_NAME, S3_REGION } from "../../AWS_IAM";
+import { IAM_ID, IAM_SECRETKEY, BUCKET_NAME } from "../../AWS_IAM";
 import AWS, { Credentials } from "aws-sdk";
 
 const access = new Credentials({
@@ -33,7 +33,7 @@ const uploadToBucket = async (preSignedUrl, file, fileType) => {
       "x-amz-acl": "public-read",
     },
   };
-  let rtn = await fetch(preSignedUrl, option);
+  await fetch(preSignedUrl, option);
   return;
 };
 


### PR DESCRIPTION
### 변경사항
- 불필요한 변수 삭제
- filter 함수가 아무것도 리턴하지 않아서 forEach로 변경
- 리액트 훅 순서 재배치
- 테이블에 <thead>, <tbody> 태그 추가
- 유의미한 데이터를 가지고 있는 tr 들중 key가 필요한 tr에 한해 key prop 추가
- option 태그에 key prop 추가
- loading시 렌더링 될 때의 select의 onChange Event 추가
- AutoSelectBox의 defaultValue 옵션을 value로 변경해서 controllable할 때 경고를 제거하였고, option이 렌더링 되지 않았을때 값 설정이 되지 않는 상황을 위해 filterSelectedOptions를 추가하고 options에 defaultValue 포함

### 결과
- 경고 제거